### PR TITLE
Fix #93 Er moet een file upload voor kernwapen vrije gemeentes

### DIFF
--- a/app/City.php
+++ b/app/City.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\MediaLibrary\HasMedia\HasMedia;
+use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
 
 /**
  * Steden model voor de databank.
@@ -14,8 +16,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @copyright   2018 Tim Joosten
  * @package     \App
  */
-class City extends Model
+class City extends Model implements HasMedia
 {
+    use HasMediaTrait;
+    
     /**
      * Mass-assign velden voor de databnak tabel.
      *

--- a/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
+++ b/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\Controller;
 use Illuminate\View\View;
 use App\City;
 use Gate;
+use Illuminate\Http\RedirectResponse;
+use App\Http\Requests\Backend\CityStatusValidator;
 
 /**
  * Class NukeFreeController
@@ -41,5 +43,10 @@ class NukeFreeController extends Controller
         }
 
         return view('backend.stadsmonitor.nuclear-not-free', compact('city'));
+    }
+
+    public function update(CityStatusValidator $input, City $city): RedirectResponse
+    {
+        dd($input, $city);
     }
 }

--- a/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
+++ b/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
@@ -9,7 +9,8 @@ use App\City;
 use Gate;
 use Illuminate\Http\RedirectResponse;
 use App\Http\Requests\Backend\CityStatusValidator;
-
+use App\Repositories\NotitionsRepository;
+use Illuminate\Support\Facades\Hash;
 /**
  * Class NukeFreeController
  * 
@@ -20,13 +21,22 @@ use App\Http\Requests\Backend\CityStatusValidator;
 class NukeFreeController extends Controller
 {
     /**
+     * De variable voor de notitie repository
+     *  
+     * @var NotitionsRepository
+     */
+    protected $notitions;
+
+    /**
      * NukeFreeController constructor 
      * 
+     * @param  NotitionsRepository $notitions The repository class voor de notities
      * @return void
      */
-    public function __construct() 
+    public function __construct(NotitionsRepository $notitions) 
     {
         $this->middleware(['auth', 'forbid-banned-user']);
+        $this->notitions = $notitions;
     }
 
     /**
@@ -38,15 +48,54 @@ class NukeFreeController extends Controller
      */
     public function show(City $city, bool $status): View 
     {
-        if (Gate::denies('kernwapen-vrij')) {
+        if (Gate::denies('kernwapen-vrij', $city)) {
             return view('backend.stadsmonitor.nuclear-free', compact('city'));
         }
 
         return view('backend.stadsmonitor.nuclear-not-free', compact('city'));
     }
 
+    /**
+     * Methode om een gemeente kernwapen vrij te verklaren. 
+     * 
+     * @param  CityStatusValidator  $input  De Form request class dat alle validatie regelt. 
+     * @param  City                 $city   De databank entiteit van de gegeven stad. 
+     * @return RedirectResponse
+     */
     public function update(CityStatusValidator $input, City $city): RedirectResponse
     {
-        dd($input, $city);
+        if (Gate::denies('kernwapen-vrij', $city) && $city->update(['kernwapen_vrij' => true])) {
+            $city->addMediaFromRequest('verklaring')->toMediaCollection('verklaringen');
+            
+            $this->notitions->notitionNuclearFree($city);
+            flash()->info(trans('flash.city-monitor.nuclear-free-true', ['name' => $city->name]));
+        } 
+
+        return redirect()->route('admin.stadsmonitor.show', $city);
+    }
+
+    /**
+     * Verwijder de kernwapen vrije status van een gemeente. 
+     * 
+     * @param  Requst   $reguest    De class that alle request information beschikbaar stelt.
+     * @param  City     $city       De databank entiteit van de gegeven stad. 
+     * @return RedirectResponse
+     */
+    public function destroy(Request $request, City $city): RedirectResponse 
+    {
+        $request->validate(['bevestiging' => 'required|string']);
+
+        if (Gate::allows('kernwapen-vrij', $city) && Hash::check($request->bevestiging, auth()->user()->password)) {
+            if ($city->update(['kernwapen_vrij' => false])) { // Het statuut is ingetrokken in de database. 
+                $city->clearMediaCollection('verklaringen');  // All media will be deleted.
+
+                $this->notitions->notitionNuclearNonFree($city);
+                flash()->info('flash.city-monitor.nuclear-free-false', ['name' => $city->name]);
+            }
+        } else { // De gemeente is niet kernwapen vrij. 
+            flash()->error('De gemeente zijn statuut als kernwapen vrije gemeente bestaat niet.');
+        }
+
+       return redirect()->route('admin.stadsmonitor.show', $city); 
     }
 }

--- a/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
+++ b/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\View\View;
 use App\City;
+use Gate;
 
 /**
  * Class NukeFreeController
@@ -35,6 +36,10 @@ class NukeFreeController extends Controller
      */
     public function show(City $city, bool $status): View 
     {
-        
+        if (Gate::denies('kernwapen-vrij')) {
+            return view('backend.stadsmonitor.nuclear-free', compact('city'));
+        }
+
+        return view('backend.stadsmonitor.nuclear-not-free', compact('city'));
     }
 }

--- a/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
+++ b/app/Http/Controllers/Backend/StadsMonitor/NukeFreeController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Backend\StadsMonitor;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Illuminate\View\View;
+use App\City;
+
+/**
+ * Class NukeFreeController
+ * 
+ * @author      Tim Joosten <Tim@activisme.be>
+ * @copyright   2018 Tim Joosten, Activisme_BE
+ * @package     App\Http\Controllers\Backend\StadsMonitor
+ */
+class NukeFreeController extends Controller
+{
+    /**
+     * NukeFreeController constructor 
+     * 
+     * @return void
+     */
+    public function __construct() 
+    {
+        $this->middleware(['auth', 'forbid-banned-user']);
+    }
+
+    /**
+     * De functie voor het maken van een status update omtrent kernwapen vrij of niet. 
+     * 
+     * @param  City $city   De databank entiteit voor de gegeven stad. (findOrFail methode)
+     * @param  bool $status De nieuwe status indicatie voor de gegeven stad.
+     * @return View 
+     */
+    public function show(City $city, bool $status): View 
+    {
+        
+    }
+}

--- a/app/Http/Controllers/Backend/StadsMonitorController.php
+++ b/app/Http/Controllers/Backend/StadsMonitorController.php
@@ -33,19 +33,13 @@ class StadsMonitorController extends Controller
     private $cityRepository;
 
     /**
-     * @var NotitionsRepository $notitionRepository
-     */
-    private $notitionRepository;
-
-    /**
      * StadsMonitorConstructor
      *
      * @param  ProvinceRepository   $provinceRepository     Abstractie laag tussen controller, logica en database
      * @param  CityRepository       $cityRepository         Abstractie laag tussen controller, logica en database
-     * @param  NotititionsRepoitory $NotitionsRepository    Abstractie laag tussen controller, logica en database
      * @return void
      */
-    public function __construct(ProvinceRepository $provinceRepository, CityRepository $cityRepository, NotitionsRepository $notitionRepository)
+    public function __construct(ProvinceRepository $provinceRepository, CityRepository $cityRepository)
     {
         parent::__construct();
 
@@ -53,7 +47,6 @@ class StadsMonitorController extends Controller
 
         $this->provinceRepository = $provinceRepository;
         $this->cityRepository     = $cityRepository;
-        $this->notitionRepository = $notitionRepository;
     }
 
     /**
@@ -85,27 +78,6 @@ class StadsMonitorController extends Controller
         $kernvrijeGemeentes = $this->cityRepository->count('kernwapen_vrij', true);
 
         return view('backend.stadsmonitor.index', compact('cities', 'kernvrijeGemeentes'));
-    }
-
-    /**
-     * Wijzig een stad zijn status in de databank.
-     *
-     * @param  int  $city   De databank entiteit van de stad
-     * @param  bool $status De door de gebruiker gegeven invoer.
-     * @return RedirectResponse
-     */
-    public function kernwapenVrij(int $city, bool $status): RedirectResponse
-    {
-        $city = $this->cityRepository->findOrFail($city);
-
-        if ($city->update(['kernwapen_vrij' => $status])) {
-            $this->addActivity($city, 'Heeft de stad ' . $city->name . ' zijn status gewijzigd.');
-            $this->notitionRepository->notitionKernvrij($status, $city->id);
-
-            flash($this->cityRepository->determineFlashSession($status, $city))->info();
-        }
-
-        return redirect()->back(302);
     }
 
     /**

--- a/app/Http/Requests/Backend/CityStatusValidator.php
+++ b/app/Http/Requests/Backend/CityStatusValidator.php
@@ -30,6 +30,6 @@ class CityStatusValidator extends FormRequest
      */
     public function rules(): array
     {
-        return ['verklaring' => 'required|max:2000|mimes:pdf'];
+        return ['verklaring' => 'required|mimes:pdf'];
     }
 }

--- a/app/Http/Requests/Backend/CityStatusValidator.php
+++ b/app/Http/Requests/Backend/CityStatusValidator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Backend;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Class CityStatusValidator
+ * 
+ * @author      Tim Joosten tim@activisme.be
+ * @copyright   2018 Tim Joosten, Activisme_BE
+ * @package     App\Http\Requests\Backend
+ */
+class CityStatusValidator extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return auth()->check() && auth()->user()->hasRole('admin');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return ['verklaring' => 'required|max:2000|mimes:pdf'];
+    }
+}

--- a/app/Http/Requests/Backend/NotitionValidator.php
+++ b/app/Http/Requests/Backend/NotitionValidator.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests\Backend;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
- * NotitionValidator
+ * Class NotitionValidator
  *
  * @author      Tim Joosten <tim@activisme.be>
  * @copyright   2018 Tim Joosten

--- a/app/Policies/CityPolicy.php
+++ b/app/Policies/CityPolicy.php
@@ -22,7 +22,7 @@ class CityPolicy
      * 
      * @param  City $city   De databank entity van de stad. 
      * @param  bool $status De status indicater die gegeven word door de gebruiker
-     * @return bool
+     * @return bool Yes, return bool. Because fuck you, that's why.
      */
     public function kernwapenVrij(City $city, bool $status): bool 
     {

--- a/app/Policies/CityPolicy.php
+++ b/app/Policies/CityPolicy.php
@@ -24,7 +24,7 @@ class CityPolicy
      * @param  bool $status De status indicater die gegeven word door de gebruiker
      * @return bool
      */
-    public function isKernwapenVrij(City $city, bool $status): bool 
+    public function kernwapenVrij(City $city, bool $status): bool 
     {
         return $city->kernwapen_vrij === $status; 
     }

--- a/app/Policies/CityPolicy.php
+++ b/app/Policies/CityPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\City;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+/**
+ * Authorisatie checker voor de handelingen die gebeuren op steden in de stadsmonitor. 
+ * 
+ * @author      Tim Joosten <tim@activisme.be>
+ * @copyright   2018 Tim Joosten, Activisme_BE
+ * @package     App\Policies
+ */
+class CityPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Check dat een gemeente als kernwapen vrij verklaard staat geregistreerd. 
+     * 
+     * @param  City $city   De databank entity van de stad. 
+     * @param  bool $status De status indicater die gegeven word door de gebruiker
+     * @return bool
+     */
+    public function isKernwapenVrij(City $city, bool $status): bool 
+    {
+        return $city->kernwapen_vrij === $status; 
+    }
+}

--- a/app/Policies/CityPolicy.php
+++ b/app/Policies/CityPolicy.php
@@ -2,8 +2,7 @@
 
 namespace App\Policies;
 
-use App\User;
-use App\City;
+use App\{User, City};
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 /**
@@ -18,14 +17,14 @@ class CityPolicy
     use HandlesAuthorization;
 
     /**
-     * Check dat een gemeente als kernwapen vrij verklaard staat geregistreerd. 
+     * Authorisatie check voor zeker te zijn dat de gegeven gemeente kernwapen vrij is. 
      * 
-     * @param  City $city   De databank entity van de stad. 
-     * @param  bool $status De status indicater die gegeven word door de gebruiker
-     * @return bool Yes, return bool. Because fuck you, that's why.
+     * @param  User $user De databank entiteit van de aangemelde gebruiker. 
+     * @param  City $city De gegeven databank entiteit van de gemeente.
+     * @return bool 
      */
-    public function kernwapenVrij(City $city, bool $status): bool 
+    public function kernwapenVrij(User $user, City $city): bool 
     {
-        return $city->kernwapen_vrij === $status; 
+        return $user->hasRole('admin') && (bool) $city->kernwapen_vrij;
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,6 +7,8 @@ use App\Policies\UserPolicy;
 use App\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Misfits\ApiGuard\Models\ApiKey;
+use App\City;
+use App\Policies\CityPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -18,6 +20,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         User::class     => UserPolicy::class,
         ApiKey::class   => ApiTokenPolicy::class,
+        City::class     => CityPolicy::class,
     ];
 
     /**

--- a/app/Repositories/CityRepository.php
+++ b/app/Repositories/CityRepository.php
@@ -47,24 +47,6 @@ class CityRepository extends Repository
     }
 
     /**
-     * Bepaal de flash message indien de gemeente kernwapen vrij is of niet.
-     *
-     * @param  bool $status De status. Is de gemeente kernwapen vrij of niet?
-     * @param  City $city   De databank entiteit van de gemeente
-     * @return string
-     */
-    public function determineFlashSession(bool $status, City $city): string
-    {
-        switch ($status) {
-            case true:  return trans('flash.city-monitor.nuclear-free-true', ['name' => $city->name]);
-            case false: return trans('flash.city-monitor.nuclear-free-false', ['name' => $city->name]);
-
-            // Indien geen van beide is gegeven
-            default: return trans('flash.city-monitor.nuclear-free-unknown');
-        }
-    }
-
-    /**
      * Zoek voor een specifieke waarde. En tel de gevonden records op.
      *
      * @param  string $column De naam van de databank kolom.

--- a/app/Repositories/NotitionsRepository.php
+++ b/app/Repositories/NotitionsRepository.php
@@ -28,7 +28,7 @@ class NotitionsRepository extends Repository
      * Prepping v/d data voor de notitie die word gebruikt als een gemeente kernwapen vrij is. 
      * 
      * @param  City $city De databank entiteit van de gegeven stad? 
-     * @return Notitions 
+     * @return void
      */
     public function notitionNuclearFree(City $city): void
     {
@@ -37,6 +37,23 @@ class NotitionsRepository extends Repository
         $notition->status       = 0; // Indication voor een publieke notitie.
         $notition->titel        = 'heeft zich kernwapen vrij verklaard.'; 
         $notition->beschrijving = "{$city->name} heeft zich kernwapen vrij verklaard."; 
+
+        $city->notitions()->save($notition);
+    }
+
+    /**
+     * Prepping v/d data voor de notitie die word gebruikt wanneer een kernwapen-vrij statuut word ingetrokken. 
+     * 
+     * @param  City $city De databank entiteit van de gegeven stad.
+     * @return void
+     */
+    public function notitionNuclearNonFree(City $city): void 
+    {
+        $notition               = new Notitions; 
+        $notition->author_id    = auth()->user()->id; 
+        $notition->status       = 0; // Indicatie voor een publieke notitie. 
+        $notition->titel        = 'Heeft zijn steun als kernwapen vrije gemeente ingetrokken.';
+        $notition->beschrijving = "{$city} heeft zijn steun als kernwapen vrije gemeente ingetrokken.";
 
         $city->notitions()->save($notition);
     }

--- a/app/Repositories/NotitionsRepository.php
+++ b/app/Repositories/NotitionsRepository.php
@@ -39,30 +39,4 @@ class NotitionsRepository extends Repository
 
         return $notition;
     }
-
-    /**
-     * Implementatie van een notitie wanneer een gemeente kernwapen vrij of niet word verklaard.
-     *
-     * @param  bool $kernwapenVrij  De status indicator. TRUE = kernwapen vrij, FALSE = niet kpernwapen vrij
-     * @param  int  $city           De unieke identificatie waarde van de stad in de databank.
-     * @return void
-     */
-    public function notitionKernvrij(bool $kernwapenVrij, int $city): void
-    {
-        $city     = City::findOrFail($city);
-
-        $notition            = new Notitions;
-        $notition->author_id = auth()->user()->id;
-        $notition->status    = 0; // Indicator voor een publieke notitie.
-
-        if ($kernwapenVrij) {
-            $notition->titel        = 'Heeft zich kernwapen vrij verklaard. ';
-            $notition->beschrijving = $city . ' heeft zich kernwapen vrij verklaard.';
-        } else {
-            $notition->titel        = 'Heeft zijn steun als kernwapen vrije gemeente ingetrokken.';
-            $notition->beschrijving = $city . ' heeft zijn steun als kernwapen vrije gemeente ingetrokken.';
-        }
-
-        $city->notitions()->save($notition);
-    }
 }

--- a/app/Repositories/NotitionsRepository.php
+++ b/app/Repositories/NotitionsRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories;
 use ActivismeBE\DatabaseLayering\Repositories\Eloquent\Repository;
 use App\City;
 use App\Notitions;
+use App\Http\Requests\Backend\CityStatusValidator;
 
 /**
  * Class NotitionsRepository
@@ -24,19 +25,19 @@ class NotitionsRepository extends Repository
     }
 
     /**
-     * Voorbereiding van de data omtrent de notitie
-     *
-     * @param  mixed $înput De data rechtstreeks van de data validator instantie.
-     * @return Notitions
+     * Prepping v/d data voor de notitie die word gebruikt als een gemeente kernwapen vrij is. 
+     * 
+     * @param  City $city De databank entiteit van de gegeven stad? 
+     * @return Notitions 
      */
-    public function prepHasMany($input): Notitions
+    public function notitionNuclearFree(City $city): void
     {
         $notition               = new Notitions;
-        $notition->author_id    = $input->user()->id;
-        $notition->titel        = $input->titel;
-        $notition->status       = $input->status;
-        $notition->beschrijving = $input->beschrijving;
+        $notition->author_id    = auth()->user()->id;
+        $notition->status       = 0; // Indication voor een publieke notitie.
+        $notition->titel        = 'heeft zich kernwapen vrij verklaard.'; 
+        $notition->beschrijving = "{$city->name} heeft zich kernwapen vrij verklaard."; 
 
-        return $notition;
+        $city->notitions()->save($notition);
     }
 }

--- a/resources/views/backend/stadsmonitor/nuclear-free.blade.php
+++ b/resources/views/backend/stadsmonitor/nuclear-free.blade.php
@@ -25,7 +25,7 @@
 
                         <hr>
 
-                        <form method="POST" action="{{ route('admin.stadsmonitor.nuke-free', $city) }}" class="form-horizontal">
+                        <form enctype="multipart/form-data" method="POST" action="{{ route('admin.stadsmonitor.nuke-free', $city) }}" class="form-horizontal">
                             {{ csrf_field() }}             {{-- Form field protection --}}
                             {{ method_field('PATCH') }}    {{-- HTTP method spoofing --}}
 
@@ -40,7 +40,7 @@
 
                             <div class="form-group">
                                 <div class="col-md-offset-3 col-md-9">
-                                    <button type="submit" class="btn btn-success">
+                                    <button type="submit" class="btn btn-sm btn-success">
                                         Invoegen
                                     </button>
                                 </div>

--- a/resources/views/backend/stadsmonitor/nuclear-free.blade.php
+++ b/resources/views/backend/stadsmonitor/nuclear-free.blade.php
@@ -25,8 +25,9 @@
 
                         <hr>
 
-                        <form method="POST" action="" class="form-horizontal">
-                            {{ csrf_field() }} {{-- Form field protection --}}
+                        <form method="POST" action="{{ route('admin.stadsmonitor.nuke-free', $city) }}" class="form-horizontal">
+                            {{ csrf_field() }}             {{-- Form field protection --}}
+                            {{ method_field('PATCH') }}    {{-- HTTP method spoofing --}}
 
                             <div class="form-group">
                                 <label class="col-md-3 control-label" for="verklaring">Verklaring <span class="text-danger">*</span></label>
@@ -40,7 +41,7 @@
                             <div class="form-group">
                                 <div class="col-md-offset-3 col-md-9">
                                     <button type="submit" class="btn btn-success">
-                                        Vrij verklaren
+                                        Invoegen
                                     </button>
                                 </div>
                             </div>

--- a/resources/views/backend/stadsmonitor/nuclear-free.blade.php
+++ b/resources/views/backend/stadsmonitor/nuclear-free.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.backend')
+
+@section('content')
+    <div class="container">
+        @include ('flash::message') {{-- Flash session view include --}}
+
+        <div class="row">
+            <div class="col-md-9">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <i class="fa fa-fw fa-pencil" aria-hidden="true"></i>
+                        <strong>{{ $city->name}}</strong> kernwapen vrij verklaren.
+                    </div>
+
+                    <div class="panel-body">
+                        <p>
+                            U staat op het punt om een gemeente kernwapen vrij te verklaren. Dit kan alleen gebeuren
+                            als er een schriftelijk bewijs is van de schepenen en of burgemeester van {{ $city->name }}.
+                        </p>
+
+                        <p>
+                            Deze verklaring zult u mee moeten uploaden. Zodat deze openbaar kan worden geplaatst voor de bezoekers
+                            en medewerkers van die actie. 
+                        </p>
+
+                        <hr>
+
+                        <form method="POST" action="" class="form-horizontal">
+                            {{ csrf_field() }} {{-- Form field protection --}}
+
+                            <div class="form-group">
+                                <label class="col-md-3 control-label" for="verklaring">Verklaring <span class="text-danger">*</span></label>
+                                
+                                <div class="col-md-9 @error('verklaring', 'has-error')">
+                                    <input type="file" id="verklaring" @input('verklaring')>
+                                    @error('verklaring')
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <div class="col-md-offset-3 col-md-9">
+                                    <button type="submit" class="btn btn-success">
+                                        Vrij verklaren
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-3">
+                <div class="list-group">
+                    <a href="{{ route('admin.stadsmonitor.show', $city) }}" class="list-group-item">
+                        <i class="fa fa-fw fa-arrow-left"></i> Terug naar het stads overzicht
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/backend/stadsmonitor/nuclear-not-free.blade.php
+++ b/resources/views/backend/stadsmonitor/nuclear-not-free.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.backend')
+
+@section('content')
+    <div class="container">
+        <div class="row">
+            <div class="col-md-9">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <i class="fa fa-fw fa-undo" aria-hidden="true"></i> 
+                        Kernwapen vrij statuut intrekken voor <strong>{{ $city->name}}</strong>
+                    </div>
+
+                    <div class="panel-body">
+                        <p class="text-danger">
+                            <i class="fa fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
+                            U staat op het punt om een kernwapen vrij statuut voor een gemeente in te trekken.
+                        </p>
+
+                        <p>
+                            Als u zeker bent van deze keuze dan kunt het statuut nietig verklaren door het ingeven van je 
+                            wachtwoord <br> onderaan in het formulier als controle.
+                        </p>
+
+                        <hr>
+
+                        <form method="POST" action="{{ route('admin.stadsmonitor.nuke-not-free', $city) }}" class="form-horizontal">
+                            {{ csrf_field() }}
+                            {{ method_field('DELETE') }}    {{-- HTTP method spoofing --}}
+
+                            <div class="form-group">
+                                <label for="bevestiging" class="control-label col-md-2">
+                                    Bevestiging <span class="text-danger">*</span>
+                                </label>
+
+                                <div class="col-md-4 @error('bevestiging', 'has-error')">
+                                    <input type="password" placeholder="Uw wachtwoord ter bevestiging" @input('bevestiging') class="form-control">
+                                    @error('bevestiging')
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <div class="col-md-offset-2 col-md-10">
+                                    <button type="submit" class="btn btn-sm btn-danger">
+                                        Bevestig
+                                    </button>
+                                </div> 
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-3">
+                <div class="list-group">
+                    <a href="{{ route('admin.stadsmonitor.show', $city) }}" class="list-group-item">
+                        <i class="fa fa-fw fa-arrow-left"></i> Terug naar het stads overzicht
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/backend/stadsmonitor/show.blade.php
+++ b/resources/views/backend/stadsmonitor/show.blade.php
@@ -31,6 +31,8 @@
 
                                             @if ($city->kernwapen_vrij) {{-- Gemeente is kernwapen vrij --}}
                                                 <span class="label label-success">Kernwapen vrij</span>
+
+                                                (<a _target="blank" href="{{ $city->getFirstMediaUrl('verklaringen') }}">Verklaring</a>)
                                             @else {{-- Gemeente is niet kernwapen vrij --}}
                                                 <span class="label label-danger">Niet kernwapen vrij</span>
                                             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,7 +65,7 @@ Route::get('/admin/zoek/stad', 'Backend\StadsMonitorController@search')->name('a
 // City status pages
 Route::get('/admin/stadsmonitor/{city}/{status}', 'Backend\StadsMonitor\NukeFreeController@show')->name('admin.stadsmonitor.status');
 Route::patch('/admin/statsmonitor/{city}/nuke-free', 'Backend\StadsMonitor\NukeFreeController@update')->name('admin.stadsmonitor.nuke-free');
-
+Route::delete('/admin/statsmonitor/{city}/nuke-not-free', 'Backend\StadsMonitor\NukeFreeController@destroy')->name('admin.stadsmonitor.nuke-not-free');
 // Stads monitor routes (Frontend)
 Route::get('/stadsmonitor', 'Frontend\StadsMonitorController@index')->name('stadsmonitor.index');
 Route::get('/stadsmonitor/zoek', 'Frontend\StadsMonitorController@search')->name('stadsmonitor.search');

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,10 @@ Route::get('/admin/stadsmonitor/{city}/{status}', 'Backend\StadsMonitor\NukeFree
 Route::get('/admin/stadsmonitor/{city}', 'Backend\StadsMonitorController@show')->name('admin.stadsmonitor.show');
 Route::get('/admin/zoek/stad', 'Backend\StadsMonitorController@search')->name('admin.stadsmonitor.search');
 
+// City status pages
+Route::get('/admin/stadsmonitor/{city}/{status}', 'Backend\StadsMonitor\NukeFreeController@show')->name('admin.stadsmonitor.status');
+Route::patch('/admin/statsmonitor/{city}/nuke-free', 'Backend\StadsMonitor\NukeFreeController@update')->name('admin.stadsmonitor.nuke-free');
+
 // Stads monitor routes (Frontend)
 Route::get('/stadsmonitor', 'Frontend\StadsMonitorController@index')->name('stadsmonitor.index');
 Route::get('/stadsmonitor/zoek', 'Frontend\StadsMonitorController@search')->name('stadsmonitor.search');

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,7 +58,7 @@ Route::get('/admin/logs/zoek', 'Backend\ActivityController@search')->name('admin
 
 // Stads monitor routes (Backend)
 Route::get('/admin/stadsmonitor', 'Backend\StadsMonitorController@index')->name('admin.stadsmonitor.index');
-Route::get('/admin/stadsmonitor/{city}/{status}', 'Backend\StadsMonitorController@kernwapenVrij')->name('admin.stadsmonitor.status');
+Route::get('/admin/stadsmonitor/{city}/{status}', 'Backend\StadsMonitor\NukeFreeController@show')->name('admin.stadsmonitor.status');
 Route::get('/admin/stadsmonitor/{city}', 'Backend\StadsMonitorController@show')->name('admin.stadsmonitor.show');
 Route::get('/admin/zoek/stad', 'Backend\StadsMonitorController@search')->name('admin.stadsmonitor.search');
 


### PR DESCRIPTION
PR. Dat toe staat wanneer een gemeente naar kernwapen vrij gezet word dat men een varklaring moet inhouden (.pdf). En bij het verwijderen van het statuut Dat de betreffende gebruiker als extra maatregel eerst zijn wachtwoord nog moet ingeven. Al vorens het statuut word verwijderd. 